### PR TITLE
Treats strings in blocks as single element arrays

### DIFF
--- a/src/templayed.js
+++ b/src/templayed.js
@@ -29,6 +29,7 @@ templayed = function(template, vars) {
     return tag(template.replace(/\{\{(\^|#)(.*?)}}(.*?)\{\{\/\2}}/g, function(match, operator, key, context) {
       var i = inc++;
       return ['"; var o', i, ' = ', get(key), '; ',
+        'o', i, ' = (o', i, ' && typeof o', i, ' == "string") ? [o', i, '] : o', i, '; ',
         (operator == "^" ?
           ['if ((o', i, ' instanceof Array) ? !o', i, '.length : !o', i, ') { s += "', block(context), '"; } '] :
           ['if (typeof(o', i, ') == "boolean" && o', i, ') { s += "', block(context), '"; } else if (o', i, ') { for (var i', i, ' = 0; i', i, ' < o',

--- a/test/assets/tests.js
+++ b/test/assets/tests.js
@@ -82,8 +82,18 @@ var inspect = function(object) {
     expected  = "<p>This is shown!</p>";
     equal(templayed(template)(variables), expected, inspect(template) + ", " + inspect(variables));
 
+    template  = "<p>This is shown!{{#show}} Psst, this is never shown{{/show}}</p>",
+    variables = {show: ''},
+    expected  = "<p>This is shown!</p>";
+    equal(templayed(template)(variables), expected, inspect(template) + ", " + inspect(variables));
+
     template  = "<p>This is shown!{{#show}} And, this is also shown{{/show}}</p>",
     variables = {show: true},
+    expected  = "<p>This is shown! And, this is also shown</p>";
+    equal(templayed(template)(variables), expected, inspect(template) + ", " + inspect(variables));
+
+    template  = "<p>This is {{show}}!{{#show}} And, this is also {{.}}{{/show}}</p>",
+    variables = {show: 'shown'},
     expected  = "<p>This is shown! And, this is also shown</p>";
     equal(templayed(template)(variables), expected, inspect(template) + ", " + inspect(variables));
   });


### PR DESCRIPTION
Prevents blocks from iterating over every character in a string rather
than being conditional on the string's truthiness.

Fix for archan937/templayed.js#18